### PR TITLE
Fixed anchor to "Web Scraping / Mining" heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Driver](#driver)
 - [Online Tools](#online-tools)
 - [Cloud Services](#cloud-services)
-- [Web Scraping / Mining](#web-scraping-mining)
+- [Web Scraping / Mining](#web-scraping--mining)
 - [Specifications](#specifications)
 - [Blogs](#blogs)
 


### PR DESCRIPTION
I noticed that the anchor tag for "Web Scraping / Mining" was not working as expected (due to the spaces surrounding the '/'). I updated the anchor.