### PR TITLE
Updating watir url

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 #### Ruby
 
 - [Selenium with Ruby](http://seleniumhq.github.io/selenium/docs/api/rb/index.html) - Selenium Ruby bindings
-- [Watir](https://watir.com/) - Automated testing that doesn’t hurt
+- [Watir](http://watir.github.io) - Automated testing that doesn’t hurt
 - [Anemone](https://github.com/chriskite/anemone) - Anemone web-spider framework.
 - [Mechanize](http://docs.seattlerb.org/mechanize/) - automating interaction with websites.
 - [Spidr](https://github.com/postmodern/spidr) - web spidering library that can spider a site, multiple domains, certain links or infinitely.


### PR DESCRIPTION
Which also fixes the Travis Build

I asked @titusfortner about the url and he confirmed me that they moved to the one I put in the PR.