### PR TITLE
docs(readme): add seleniumQuery to java section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Selenide](https://github.com/codeborne/selenide) - A framework for writing easy-to-read and easy-to-maintain automated tests using a Fluent API. Selenide has a magic trick that resolves most problems with Ajax and timeouts.
 - [Galen Framework](http://galenframework.com/) - Automated testing of look and feel for your responsive websites.
 - [Serenity](http://www.thucydides.info/) - It is an open source library for writing better quality automated acceptance tests faster. (Formerly Thucydides).
+- [seleniumQuery](https://github.com/seleniumQuery/seleniumQuery) - jQuery-like cross-driver interface in Java for WebDriver. Designed as a thin layer, it can be used alone or on top of your favorite framework just to make some cases (e.g. asserting/waiting) simpler when needed.
 
 #### C#
 


### PR DESCRIPTION
> The pull request should include a link to the package and why it should be included

- Link: https://github.com/seleniumQuery/seleniumQuery
- Why? seleniumQuery is a simple tool that can be added to any JVM selenium project without a hassle. It is stable and has been developed for over 4 years. Heavily tested (~85%).
- Disclaimer: I'm one of the authors.