### PR TITLE
Added Puppeteer to the web scraping section

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [Scrapy](http://scrapy.org) - **Python**, mainly a scraper/miner - fast, well documented and, can be linked with [Django Dynamic Scraper](http://django-dynamic-scraper.readthedocs.org/en/latest/) for nice mining deployments, or [Scrapy Cloud](http://scrapinghub.com/scrapy-cloud.html) for PaaS (server-less) deployment, works in terminal or an server stand-alone proces, can be used with **Celery**, built on top of **Twisted**.
 - [Node-Crawler](https://github.com/sylvinus/node-crawler) - **Node.js** Web Crawler/Spider for NodeJS + server-side jQuery.
+- [Puppeteer](https://github.com/GoogleChrome/puppeteer) - Puppeteer is a **Node.js** library which provides a high-level API to control Chrome or Chromium over the DevTools Protocol.
 
 ### Specifications
 


### PR DESCRIPTION
Puppeteer is now very popular in the web scraping field compared to Python as it has a very low footprint and with built-in chromium browser version.