### PR TITLE
Add WebGrid to K8s section

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [kubernetes/examples](https://github.com/kubernetes/examples/tree/master/staging/selenium) - Example deployment of Selenium Hub and Nodes on a Kubernetes cluster
 - [Moon](https://github.com/aerokube/moon) - A commercial closed-source enterprise Selenium implementation using Kubernetes to launch browsers
 - [Callisto](https://github.com/wrike/callisto) - An open-source tool to launch browsers in Kubernetes. Separate is created for each selenium session.
+- [WebGrid](https://github.com/TilBlechschmidt/WebGrid) - An open-source, decentralized, scalable and robust selenium-grid equivalent.
 
 ### Driver
 


### PR DESCRIPTION
This PR adds [WebGrid](https://github.com/TilBlechschmidt/WebGrid) to the Containers/Kubernetes section of this awesome-list. It is a re-implementation of the honestly very dated Selenium Grid with a focus on performance, scalability and availability. Documentation can be found [here](https://webgrid.dev).

It should be included because we (maintainers of the project) are getting good use out of it and hope that others can benefit from it as well 🙂 