### PR TITLE
Add selenosis to the list of Kubernetes tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Moon](https://github.com/aerokube/moon) - A commercial closed-source enterprise Selenium implementation using Kubernetes to launch browsers
 - [Callisto](https://github.com/wrike/callisto) - An open-source tool to launch browsers in Kubernetes. Separate is created for each selenium session.
 - [WebGrid](https://github.com/TilBlechschmidt/WebGrid) - An open-source, decentralized, scalable and robust selenium-grid equivalent.
+- [selenosis](https://github.com/alcounit/selenosis) - Stateless, Kubernetes-native platform that runs ephemeral Selenium, Playwright, and MCP browser sessions as on-demand pods via custom resources.
 
 ### Driver
 


### PR DESCRIPTION
Adds [selenosis](https://github.com/alcounit/selenosis) to the list.

Selenosis is a Kubernetes-native, stateless alternative to Selenium Grid. Each WebDriver session is provisioned as a dedicated, ephemeral pod (one session = one pod) — no warm pools and no shared browsers. It also supports Playwright and MCP. 

Sessions are modeled as Kubernetes custom resources. A `Browser` resource represents a single browser session (browser name and version) and is reconciled into a pod, while a `BrowserConfig` resource defines the browser images and pod templates, with a deterministic merge order (version → browser → template). This makes browser provisioning declarative, with Kubernetes as the single source of truth.