### PR TITLE
Add invisible_playwright to Web Scraping / Mining

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [Scrapy](http://scrapy.org) - **Python**, mainly a scraper/miner - fast, well documented and, can be linked with [Django Dynamic Scraper](http://django-dynamic-scraper.readthedocs.org/en/latest/) for nice mining deployments, or [Scrapy Cloud](http://scrapinghub.com/scrapy-cloud.html) for PaaS (server-less) deployment, works in terminal or an server stand-alone process, can be used with **Celery**, built on top of **Twisted**.
 - [Node-Crawler](https://github.com/sylvinus/node-crawler) - **Node.js** Web Crawler/Spider for NodeJS + server-side jQuery.
+- [invisible_playwright](https://github.com/feder-cr/invisible_playwright) - **Python**, Playwright wrapper over a patched Firefox with a realistic, consistent browser fingerprint for scraping pages that filter automated browsers.
 
 ### Specifications
 


### PR DESCRIPTION
adds invisible_playwright under web scraping / mining. it's a python playwright wrapper over a patched firefox that keeps a realistic, consistent fingerprint, handy for scraping pages that filter automated browsers. that section already lists general scraping tools (scrapy, node-crawler) so it seemed in scope. opened as draft, happy to adjust.